### PR TITLE
UT-1374-Opening_publish_app_without_recording_shows_last_recorded_session_for_upload

### DIFF
--- a/Shotgun/Packages/com.unity.integrations.shotgun/Editor/RecordTimeline.cs
+++ b/Shotgun/Packages/com.unity.integrations.shotgun/Editor/RecordTimeline.cs
@@ -67,6 +67,11 @@ namespace UnityEditor.Integrations.Shotgun
             }
         }
 
+        /// <summary>
+        /// Returns a deterministic path based on the project name
+        /// e.g. %TEMP%\Unity_Project_Name for the Windows platform
+        /// </summary>
+        /// <returns>The path</returns>
         private static string GetTempFilePath()
         {
             // store to a temporary path, to delete after publish
@@ -82,7 +87,7 @@ namespace UnityEditor.Integrations.Shotgun
         {
             if (IsRecording)
             {
-                // Domain reloads loses the overriden Recorder path. We know a 
+                // Domain reloads lose the overriden Recorder path. We know a 
                 // domain reload occurred if m_origFilePath is not set (cleared 
                 // by a domain reload)
                 if (null == s_origFilePath)


### PR DESCRIPTION
* Now deleting the temp movie file before recording

This complements the fix made in tk-unity