### PR TITLE
UT-1735 	Syntax fixes in "Setting Up tk-config-default2"

### DIFF
--- a/Shotgun/Packages/com.unity.integrations.shotgun/Documentation~/configDefault.md
+++ b/Shotgun/Packages/com.unity.integrations.shotgun/Documentation~/configDefault.md
@@ -4,7 +4,7 @@
 2. Add the following section:
     ```
     # Unity
-    Engines.tk-unity.location:
+    engines.tk-unity.location:
       type: dev
       path: '{CONFIG_FOLDER}/tk-unity'
     ```
@@ -14,7 +14,9 @@
 3. Edit env/project.yml
 
     Add this to the includes section:
-        * ./includes/settings/tk-unity.yml
+	```
+        - ./includes/settings/tk-unity.yml
+	```
         
   Also add the tk-unity engine under engines:
     
@@ -62,7 +64,7 @@
 5. In env/includes/settings/tk-multi-breakdown.yml, add the following:
     ```
     settings.tk-multi-breakdown.unity:
-      hook_scene_operations: "{engine}/tk-multi-breakdown/tk-unity_scene_operations.py"
+      hook_scene_operations: '{engine}/tk-multi-breakdown/tk-unity_scene_operations.py'
       location: "@apps.tk-multi-breakdown.location"
     ```
 


### PR DESCRIPTION
I fixed some of the doc issues reported in UT-1735.

Please verify that the page Machine Setup / Shotgun Configuration / Other Configurations / tk-config-default2 looks okay on your end as well.