### PR TITLE
UT-1735 Fixed faulty code in custom config instructions.

### DIFF
--- a/Shotgun/Packages/com.unity.integrations.shotgun/Documentation~/configDefault.md
+++ b/Shotgun/Packages/com.unity.integrations.shotgun/Documentation~/configDefault.md
@@ -50,7 +50,8 @@
 
         tk-multi-loader2: "@settings.tk-multi-loader2.unity"
 
-        tk-multi-shotgunpanel: "@apps.tk-multi-shotgunpanel.location"
+        tk-multi-shotgunpanel:
+          location: "@apps.tk-multi-shotgunpanel.location"
 
         tk-multi-pythonconsole:
           location: "@apps.tk-multi-pythonconsole.location"


### PR DESCRIPTION
The cause of UT-1735 was incorrect code given in 'Setting Up tk-config-default2'. Here it is fixed.