### PR TITLE
UT-2526-TestRunner_fails_because_it_times_out_too_early

### DIFF
--- a/Shotgun/Packages/com.unity.integrations.shotgun/Tests/ShotgunTests.cs
+++ b/Shotgun/Packages/com.unity.integrations.shotgun/Tests/ShotgunTests.cs
@@ -34,7 +34,7 @@ namespace Tests
             PythonRunner.RunFileOnClient(standaloneScript);
 
             // Give the script some time to publish
-            yield return Wait(10000);
+            yield return Wait(15000);
 
             // Upon success, the Python script creates a game object named 
             // after the product name


### PR DESCRIPTION
We give 10 seconds to the client to successfully publish a video.This is on the edge of what is currently possible for our Linux laptop. Sometimes it takes slightly more than 10 seconds 

Fix is to raise the timeout value in the test