### PR TITLE
UT3579 Fix bad regex

### DIFF
--- a/Tests/ShotgunTests.cs
+++ b/Tests/ShotgunTests.cs
@@ -102,7 +102,7 @@ namespace Tests
         {
             var qaReportFile = Path.GetFullPath("Packages/com.unity.integrations.shotgun/QAReport.md");
             var changelogFile = Path.GetFullPath("Packages/com.unity.integrations.shotgun/CHANGELOG.md");
-            var versionRegex = @"\[\d.\d.\d(\-preview(\.\d{1,3})?)?\]";
+            var versionRegex = @"\[\d+.\d+.\d+(\-preview(\.\d{1,3})?)?\]";
             Assert.True(File.Exists(qaReportFile));
             using (StreamReader qaReport = new StreamReader(qaReportFile), 
                                 changelog = new StreamReader(changelogFile))


### PR DESCRIPTION
The QaReportTest was finding 0.9.0, but not 0.10.0.
Make the regex match more than 1 digit.